### PR TITLE
feat: add scrolling

### DIFF
--- a/AvaloniaTerminal.sln
+++ b/AvaloniaTerminal.sln
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XtermSharp", "src\XtermSharp\XtermSharp.csproj", "{F865E554-E33E-4116-B688-F75A74560008}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AvaloniaTerminal.Tests", "tests\AvaloniaTerminal.Tests\AvaloniaTerminal.Tests.csproj", "{7AACA4AE-DD7B-4C08-9D63-29C2BEF75611}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,10 @@ Global
 		{0CCFA5E1-E491-42EC-9F7D-E3638638D4DE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F865E554-E33E-4116-B688-F75A74560008}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F865E554-E33E-4116-B688-F75A74560008}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {7AACA4AE-DD7B-4C08-9D63-29C2BEF75611}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {7AACA4AE-DD7B-4C08-9D63-29C2BEF75611}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {7AACA4AE-DD7B-4C08-9D63-29C2BEF75611}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {7AACA4AE-DD7B-4C08-9D63-29C2BEF75611}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F865E554-E33E-4116-B688-F75A74560008}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F865E554-E33E-4116-B688-F75A74560008}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/src/AvaloniaTerminal/TerminalControl.cs
+++ b/src/AvaloniaTerminal/TerminalControl.cs
@@ -1,25 +1,47 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Input;
+using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Media.TextFormatting;
+using System;
+using System.ComponentModel;
 using System.Globalization;
 using XtermSharp;
 using Point = Avalonia.Point;
 
 namespace AvaloniaTerminal;
 
-public partial class TerminalControl : Control
+public partial class TerminalControl : Panel
 {
     private Size _consoleTextSize;
 
     private Typeface _typeface;
+
+    private const double ScrollBarWidth = 12;
+
+    private readonly ScrollBar _scrollBar;
+    private readonly TerminalPresenter _presenter;
+    private bool _ignoreScrollBarChange;
 
     public TerminalControl()
     {
         Focusable = true;
 
         this.Focus(NavigationMethod.Pointer);
+
+        _scrollBar = new ScrollBar
+        {
+            Orientation = Orientation.Vertical,
+            Width = ScrollBarWidth,
+            IsVisible = false
+        };
+        _scrollBar.PropertyChanged += ScrollBarChanged;
+
+        _presenter = new TerminalPresenter(this);
+        Children.Add(_presenter);
+        Children.Add(_scrollBar);
 
         CalculateTextSize();
     }
@@ -29,8 +51,25 @@ public partial class TerminalControl : Control
     public TerminalControlModel Model
     {
         get => GetValue(TerminalProperty);
-        set { SetValue(TerminalProperty, value);
-            Model.UpdateUI = InvalidateVisual;
+        set
+        {
+            if (Model != null)
+            {
+                Model.PropertyChanged -= ModelPropertyChanged;
+            }
+
+            SetValue(TerminalProperty, value);
+
+            if (value != null)
+            {
+                value.UpdateUI = () =>
+                {
+                    UpdateScrollBar();
+                    InvalidateVisual();
+                };
+                value.PropertyChanged += ModelPropertyChanged;
+                UpdateScrollBar();
+            }
         }
     }
 
@@ -317,6 +356,40 @@ public partial class TerminalControl : Control
         e.Handled = true;
     }
 
+    protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
+    {
+        base.OnPointerWheelChanged(e);
+
+        if (Model == null)
+        {
+            return;
+        }
+
+        var lines = (int)Math.Round(e.Delta.Y);
+        if (lines != 0)
+        {
+            Model.ScrollLines(-lines);
+        }
+
+        e.Handled = true;
+    }
+
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        var contentWidth = Math.Max(0, availableSize.Width - ScrollBarWidth);
+        _presenter.Measure(new Size(contentWidth, availableSize.Height));
+        _scrollBar.Measure(new Size(ScrollBarWidth, availableSize.Height));
+        return availableSize;
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        var sbWidth = _scrollBar.IsVisible ? ScrollBarWidth : 0;
+        _presenter.Arrange(new Rect(0, 0, finalSize.Width - sbWidth, finalSize.Height));
+        _scrollBar.Arrange(new Rect(finalSize.Width - sbWidth, 0, sbWidth, finalSize.Height));
+        return finalSize;
+    }
+
     protected override void OnSizeChanged(SizeChangedEventArgs e)
     {
         base.OnSizeChanged(e);
@@ -326,9 +399,53 @@ public partial class TerminalControl : Control
             return;
         }
 
-        Model.Resize(Bounds.Width, Bounds.Height, _consoleTextSize.Width, _consoleTextSize.Height);
+        var width = Bounds.Width - (_scrollBar.IsVisible ? ScrollBarWidth : 0);
+        Model.Resize(width, Bounds.Height, _consoleTextSize.Width, _consoleTextSize.Height);
         InvalidateVisual();
     }
+
+    private void ModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(TerminalControlModel.CanScroll))
+        {
+            UpdateScrollBar();
+        }
+    }
+
+    private void ScrollBarChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+    {
+        if (e.Property == RangeBase.ValueProperty && !_ignoreScrollBarChange && Model != null)
+        {
+            var target = (int)Math.Round(_scrollBar.Value);
+            var diff = target - Model.Terminal.Buffer.YDisp;
+            if (diff != 0)
+            {
+                Model.ScrollLines(diff);
+            }
+        }
+    }
+
+    private void UpdateScrollBar()
+    {
+        if (Model == null)
+        {
+            return;
+        }
+
+        var max = Math.Max(0, Model.Terminal.Buffer.Lines.Length - Model.Terminal.Rows);
+        _scrollBar.Maximum = max;
+        _scrollBar.ViewportSize = Model.Terminal.Rows;
+        _ignoreScrollBarChange = true;
+        _scrollBar.Value = Model.Terminal.Buffer.YDisp;
+        _ignoreScrollBarChange = false;
+        _scrollBar.IsVisible = Model.CanScroll;
+        InvalidateArrange();
+
+        var width = Bounds.Width - (_scrollBar.IsVisible ? ScrollBarWidth : 0);
+        Model.Resize(width, Bounds.Height, _consoleTextSize.Width, _consoleTextSize.Height);
+    }
+
+    protected ScrollBar VerticalScrollBar => _scrollBar;
 
     public static Brush ConvertXtermColor(int xtermColor)
     {
@@ -346,9 +463,10 @@ public partial class TerminalControl : Control
         _consoleTextSize = run.Size;
     }
 
-    public override void Render(DrawingContext context)
+    internal void RenderTerminal(DrawingContext context)
     {
-        var rect = new Rect(0,0, Bounds.Width, Bounds.Height);
+        var contentWidth = Bounds.Width - (_scrollBar.IsVisible ? ScrollBarWidth : 0);
+        var rect = new Rect(0, 0, contentWidth, Bounds.Height);
         context.FillRectangle(ConvertXtermColor(0), rect);
 
         if (Model == null)
@@ -367,6 +485,21 @@ public partial class TerminalControl : Control
             formattedText.SetFontStyle(item.Value.FontStyle);
 
             context.DrawText(formattedText, new Point(_consoleTextSize.Width * item.Key.x, _consoleTextSize.Height * item.Key.y));
+        }
+    }
+
+    private sealed class TerminalPresenter : Control
+    {
+        private readonly TerminalControl _owner;
+
+        public TerminalPresenter(TerminalControl owner)
+        {
+            _owner = owner;
+        }
+
+        public override void Render(DrawingContext context)
+        {
+            _owner.RenderTerminal(context);
         }
     }
 }

--- a/src/AvaloniaTerminal/TerminalControlModel.cs
+++ b/src/AvaloniaTerminal/TerminalControlModel.cs
@@ -43,44 +43,6 @@ public partial class TerminalControlModel : ObservableObject, ITerminalDelegate
     public bool OptionAsMetaKey { get; set; } = true;
 
     /// <summary>
-    /// Gets a value indicating the relative position of the terminal scroller
-    /// </summary>
-    public double ScrollPosition
-    {
-        get
-        {
-            if (Terminal.Buffers.IsAlternateBuffer)
-                return 0;
-
-            // strictly speaking these ought not to be outside these bounds
-            if (Terminal.Buffer.YDisp <= 0)
-                return 0;
-
-            var maxScrollback = Terminal.Buffer.Lines.Length - Terminal.Rows;
-            if (Terminal.Buffer.YDisp >= maxScrollback)
-                return 1;
-
-            return (double)Terminal.Buffer.YDisp / (double)maxScrollback;
-        }
-    }
-
-    /// <summary>
-    /// Gets a value indicating the scroll thumbsize
-    /// </summary>
-    public float ScrollThumbsize
-    {
-        get
-        {
-            if (Terminal.Buffers.IsAlternateBuffer)
-                return 0;
-
-            // the thumb size is the proportion of the visible content of the
-            // entire content but don't make it too small
-            return Math.Max((float)Terminal.Rows / (float)Terminal.Buffer.Lines.Length, 0.01f);
-        }
-    }
-
-    /// <summary>
     /// Gets a value indicating whether or not the user can scroll the terminal contents
     /// </summary>
     public bool CanScroll
@@ -158,6 +120,7 @@ public partial class TerminalControlModel : ObservableObject, ITerminalDelegate
 
         Terminal?.Resize(cols, rows);
         RemoveItemsDictionary();
+        UpdateScroller();
 
         SizeChanged?.Invoke(cols, rows, width, height);
     }
@@ -222,8 +185,14 @@ public partial class TerminalControlModel : ObservableObject, ITerminalDelegate
         }
 
         //UpdateCursorPosition();
-        //UpdateScroller();
+        UpdateScroller();
         UpdateUI?.Invoke();
+    }
+
+    public void ScrollLines(int disp)
+    {
+        Terminal.ScrollLines(disp);
+        UpdateDisplay();
     }
 
     public void Feed(string text)
@@ -236,6 +205,11 @@ public partial class TerminalControlModel : ObservableObject, ITerminalDelegate
         SearchService?.Invalidate();
         Terminal?.Feed(text, length);
         UpdateDisplay();
+    }
+
+    private void UpdateScroller()
+    {
+        OnPropertyChanged(nameof(CanScroll));
     }
 
     private static TextObject SetStyling(TextObject control, CharData cd)

--- a/tests/AvaloniaTerminal.Tests/AvaloniaTerminal.Tests.csproj
+++ b/tests/AvaloniaTerminal.Tests/AvaloniaTerminal.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Avalonia.Headless.XUnit" Version="11.3.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AvaloniaTerminal\AvaloniaTerminal.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/AvaloniaTerminal.Tests/TerminalControlTests.cs
+++ b/tests/AvaloniaTerminal.Tests/TerminalControlTests.cs
@@ -1,0 +1,69 @@
+using Avalonia;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Controls;
+using Xunit;
+
+namespace AvaloniaTerminal.Tests;
+
+public class TerminalControlTests
+{
+    private class TestTerminalControl : TerminalControl
+    {
+        public ScrollBar ScrollBar => VerticalScrollBar;
+        public void RaisePointerWheel(PointerWheelEventArgs e) => base.OnPointerWheelChanged(e);
+    }
+
+    // Verifies that pointer wheel events adjust the terminal's scroll position
+    [AvaloniaFact]
+    public void PointerWheelScroll_ChangesBufferOffset()
+    {
+        var model = new TerminalControlModel();
+        var control = new TestTerminalControl { Model = model };
+
+        // Populate terminal with enough lines to enable scrolling
+        for (var i = 0; i < model.Terminal.Rows + 10; i++)
+        {
+            model.Feed($"line {i}\n");
+        }
+
+        Assert.Equal(0, model.Terminal.Buffer.YDisp);
+
+        var pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, true);
+        var properties = new PointerPointProperties();
+
+        // Simulate wheel down (negative Y delta) to scroll up one line
+        var scrollUp = new PointerWheelEventArgs(control, pointer, control, new Point(), 0, properties, KeyModifiers.None, new Vector(0, -1));
+        control.RaisePointerWheel(scrollUp);
+        Assert.Equal(1, model.Terminal.Buffer.YDisp);
+
+        // Simulate wheel up to scroll back down
+        var scrollDown = new PointerWheelEventArgs(control, pointer, control, new Point(), 0, properties, KeyModifiers.None, new Vector(0, 1));
+        control.RaisePointerWheel(scrollDown);
+        Assert.Equal(0, model.Terminal.Buffer.YDisp);
+    }
+
+    // Verifies that adjusting the scroll bar updates the buffer offset
+    [AvaloniaFact]
+    public void ScrollBarValue_ChangesBufferOffset()
+    {
+        var model = new TerminalControlModel();
+        var control = new TestTerminalControl { Model = model };
+        control.Measure(new Size(100,100));
+        control.Arrange(new Rect(0,0,100,100));
+
+        for (var i = 0; i < model.Terminal.Rows + 50; i++)
+        {
+            model.Feed($"line {i}\n");
+        }
+
+        Assert.Equal(0, model.Terminal.Buffer.YDisp);
+
+        var sb = control.ScrollBar;
+        Assert.True(sb.IsVisible);
+        sb.Value = sb.Maximum;
+
+        Assert.Equal((int)sb.Maximum, model.Terminal.Buffer.YDisp);
+    }
+}
+

--- a/tests/AvaloniaTerminal.Tests/TestApp.cs
+++ b/tests/AvaloniaTerminal.Tests/TestApp.cs
@@ -1,0 +1,18 @@
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+
+[assembly: AvaloniaTestApplication(typeof(AvaloniaTerminal.Tests.TestAppBuilder))]
+
+namespace AvaloniaTerminal.Tests;
+
+public class TestApp : Application
+{
+}
+
+public static class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<TestApp>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}


### PR DESCRIPTION
## Summary
- add headless test exercising scroll via pointer wheel events
- wire Avalonia headless test application setup
- enable `TerminalControl` to forward wheel events to the model
- add vertical scrollbar with drag support

## Testing
- `MSBUILDTERMINALLOGGER=false dotnet build --no-restore` *(fails: Failed to retrieve packages via proxy 403)*
- `dotnet test --no-restore` *(succeeds: Build succeeded but no tests were run)*

------
https://chatgpt.com/codex/tasks/task_e_68b871e7a9f8832693188440d715720b