### PR TITLE
Upgrade to Avalonia 12 and adapt APIs

### DIFF
--- a/src/AvaloniaTerminal.Desktop/AvaloniaTerminal.Desktop.csproj
+++ b/src/AvaloniaTerminal.Desktop/AvaloniaTerminal.Desktop.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.12" />
+    <PackageReference Include="Avalonia" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.1" />
     <!--Condition below is needed to remove Avalonia.DiagnosticsSupport package from build output in Release configuration.-->
-    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.1.0" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1" Condition="'$(Configuration)' == 'Debug'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AvaloniaTerminal.Samples/AvaloniaTerminal.Samples.csproj
+++ b/src/AvaloniaTerminal.Samples/AvaloniaTerminal.Samples.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.12" />
+    <PackageReference Include="Avalonia" Version="12.0.1" />
     <ProjectReference Include="..\AvaloniaTerminal\AvaloniaTerminal.csproj" />
   </ItemGroup>
 

--- a/src/AvaloniaTerminal/AvaloniaTerminal.csproj
+++ b/src/AvaloniaTerminal/AvaloniaTerminal.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.12" />
+    <PackageReference Include="Avalonia" Version="12.0.1" />
     <PackageReference Include="PropertyGenerator.Avalonia" Version="1.3.1" PrivateAssets="all" />
     <PackageReference Include="XTerm.NET" Version="1.0.12" />
   </ItemGroup>

--- a/src/AvaloniaTerminal/TerminalControl.cs
+++ b/src/AvaloniaTerminal/TerminalControl.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
@@ -231,9 +232,8 @@ public partial class TerminalControl : Grid
             {
                 return;
             }
-#pragma warning disable CS0618
-            text = await clipboard.GetTextAsync().ConfigureAwait(true);
-#pragma warning restore CS0618
+
+            text = await clipboard.TryGetTextAsync().ConfigureAwait(true);
         }
 
         if (!string.IsNullOrEmpty(text))
@@ -624,14 +624,14 @@ public partial class TerminalControl : Grid
         StopSelectionAutoScroll();
     }
 
-    protected override void OnGotFocus(GotFocusEventArgs e)
+    protected override void OnGotFocus(FocusChangedEventArgs e)
     {
         base.OnGotFocus(e);
         _hasFocus = true;
         _surface.InvalidateVisual();
     }
 
-    protected override void OnLostFocus(RoutedEventArgs e)
+    protected override void OnLostFocus(FocusChangedEventArgs e)
     {
         base.OnLostFocus(e);
         _hasFocus = false;

--- a/tests/AvaloniaTerminal.Tests/AvaloniaTerminal.Tests.csproj
+++ b/tests/AvaloniaTerminal.Tests/AvaloniaTerminal.Tests.csproj
@@ -17,8 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
-    <PackageReference Include="Avalonia.Headless" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Headless" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Summary
Upgrades the solution from Avalonia 11.3.x to Avalonia 12.0.1 and applies the code changes required by Avalonia 12 breaking changes.

Package updates
Bumped all Avalonia-related packages to 12.0.1 (Avalonia, Avalonia.Desktop, Avalonia.Themes.Fluent, Avalonia.Fonts.Inter, Avalonia.Headless).
Updated AvaloniaUI.DiagnosticsSupport to 2.2.1 (Debug-only reference, aligned with Avalonia 12 developer tools guidance).
Code changes
Focus events: OnGotFocus / OnLostFocus now use FocusChangedEventArgs instead of GotFocusEventArgs / RoutedEventArgs.
Clipboard: Replaced deprecated GetTextAsync() with TryGetTextAsync() on IClipboard.
Added using Avalonia.Input.Platform; so ClipboardExtensions (SetTextAsync / TryGetTextAsync) resolve correctly.
Verification
Solution builds in Debug and Release.
All 201 unit tests pass (net8.0, net9.0, net10.0).