### PR TITLE
chore: add hangdump

### DIFF
--- a/tests/SvcSystems.UI.Terminal.Tests/SvcSystems.UI.Terminal.Tests.csproj
+++ b/tests/SvcSystems.UI.Terminal.Tests/SvcSystems.UI.Terminal.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.3" />
     <PackageReference Include="Avalonia.Headless" Version="12.1.1" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.1" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added hang-dump support to the terminal test suite to help capture diagnostic information when tests become unresponsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->