### PR TITLE
feat: move FontFamily from string to FontFamily and remove CaretBrush and SelectionBrush Style Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,26 +269,16 @@ The desktop sample includes those resources automatically. If you host the contr
 
 `Colors.axaml` provides:
 
-- the default `TerminalControl` font settings
 - the exported 256-color terminal palette as `SvcSystems.UI.TerminalColor0` through `SvcSystems.UI.TerminalColor255`
-- resource keys that the control reads for optional caret and selection overrides
 
 Available resource keys:
 
-- `SvcSystems.UI.TerminalFontFamily`
-- `SvcSystems.UI.TerminalFontSize`
-- `SvcSystems.UI.TerminalCaretBrush`
-- `SvcSystems.UI.TerminalSelectionBrush`
 - `SvcSystems.UI.TerminalColor0` ... `SvcSystems.UI.TerminalColor255`
 
 You can override those resources at the application level to align the terminal with your app theme:
 
 ```xml
 <Application.Resources>
-    <x:String x:Key="SvcSystems.UI.TerminalFontFamily">Fira Code</x:String>
-    <x:Double x:Key="SvcSystems.UI.TerminalFontSize">14</x:Double>
-    <SolidColorBrush x:Key="SvcSystems.UI.TerminalCaretBrush" Color="#FFB000" />
-    <SolidColorBrush x:Key="SvcSystems.UI.TerminalSelectionBrush" Color="#4060A0FF" />
     <SolidColorBrush x:Key="SvcSystems.UI.TerminalColor0" Color="#111111" />
     <SolidColorBrush x:Key="SvcSystems.UI.TerminalColor15" Color="#F5F5F5" />
 </Application.Resources>
@@ -313,7 +303,7 @@ Example:
 
 Notes:
 
-- font defaults come from `Colors.axaml` and can be overridden by application resources
+- font defaults are provided by the `TerminalControl` property registrations and can be overridden by styles or direct values
 - caret and selection use the control properties first, then the corresponding application resources, then the built-in fallback behavior
 - ANSI foreground/background rendering uses the exported `SvcSystems.UI.TerminalColor*` resource keys, so hosts can replace the palette without changing library code
 

--- a/src/SvcSystems.UI.Terminal/Styles/Colors.axaml
+++ b/src/SvcSystems.UI.Terminal/Styles/Colors.axaml
@@ -1,11 +1,8 @@
 <Styles
     xmlns="https://github.com/avaloniaui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:SvcSystems.UI.Terminal">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Styles.Resources>
         <ResourceDictionary>
-            <x:String x:Key="SvcSystems.UI.TerminalFontFamily">Cascadia Mono</x:String>
-            <x:Double x:Key="SvcSystems.UI.TerminalFontSize">12</x:Double>
             <SolidColorBrush x:Key="SvcSystems.UI.TerminalColor0" Color="#000000" />
             <SolidColorBrush x:Key="SvcSystems.UI.TerminalColor1" Color="#800000" />
             <SolidColorBrush x:Key="SvcSystems.UI.TerminalColor2" Color="#008000" />
@@ -264,9 +261,4 @@
             <SolidColorBrush x:Key="SvcSystems.UI.TerminalColor255" Color="#EEEEEE" />
         </ResourceDictionary>
     </Styles.Resources>
-
-    <Style Selector="local|TerminalControl">
-        <Setter Property="FontFamily" Value="{DynamicResource SvcSystems.UI.TerminalFontFamily}" />
-        <Setter Property="FontSize" Value="{DynamicResource SvcSystems.UI.TerminalFontSize}" />
-    </Style>
 </Styles>

--- a/src/SvcSystems.UI.Terminal/TerminalControl.cs
+++ b/src/SvcSystems.UI.Terminal/TerminalControl.cs
@@ -98,7 +98,6 @@ public partial class TerminalControl : Grid
         };
         _selectionAutoScrollTimer.Tick += OnSelectionAutoScrollTimerTick;
 
-        ApplyResourceDefaults();
         CalculateTextSize();
         UpdateScrollBar();
     }
@@ -111,9 +110,9 @@ public partial class TerminalControl : Grid
         set => SetValue(ModelProperty, value);
     }
 
-    public static readonly StyledProperty<string> FontFamilyProperty = AvaloniaProperty.Register<TerminalControl, string>(nameof(FontFamily), "Cascadia Mono");
+    public static readonly StyledProperty<FontFamily> FontFamilyProperty = AvaloniaProperty.Register<TerminalControl, FontFamily>(nameof(FontFamily), new FontFamily("Cascadia Mono"));
 
-    public string FontFamily
+    public FontFamily FontFamily
     {
         get => GetValue(FontFamilyProperty);
         set => SetValue(FontFamilyProperty, value);
@@ -631,33 +630,6 @@ public partial class TerminalControl : Grid
 
         value = TryGetApplicationResource(resourceKey);
         return value != null;
-    }
-
-    private void ApplyResourceDefaults()
-    {
-        if (TryGetApplicationResource("SvcSystems.UI.TerminalFontFamily") is string fontFamily)
-        {
-            FontFamily = fontFamily;
-        }
-
-        if (TryGetApplicationResource("SvcSystems.UI.TerminalFontSize") is double fontSize)
-        {
-            FontSize = fontSize;
-        }
-        else if (TryGetApplicationResource("SvcSystems.UI.TerminalFontSize") is int fontSizeInt)
-        {
-            FontSize = fontSizeInt;
-        }
-
-        if (TryGetApplicationResource("SvcSystems.UI.TerminalCaretBrush") is IBrush caretBrush)
-        {
-            CaretBrush = caretBrush;
-        }
-
-        if (TryGetApplicationResource("SvcSystems.UI.TerminalSelectionBrush") is IBrush selectionBrush)
-        {
-            SelectionBrush = selectionBrush;
-        }
     }
 
     private static Brush[] CreateFallbackXtermPalette()

--- a/tests/SvcSystems.UI.Terminal.Tests/TerminalControlTests.cs
+++ b/tests/SvcSystems.UI.Terminal.Tests/TerminalControlTests.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
+using Avalonia.Media;
 using Avalonia.Threading;
 using SvcSystems.UI.Terminal;
 using SvcSystems.UI.Terminal.Samples;
@@ -236,7 +237,7 @@ public sealed class TerminalControlTests : AvaloniaTestBase
         {
             var control = CreateControl(out _, out _);
 
-            control.FontFamily = "__missing_font_family__";
+            control.FontFamily = new FontFamily("__missing_font_family__");
 
             Assert.True(control.CanRenderTextForTests);
         });
@@ -262,7 +263,7 @@ public sealed class TerminalControlTests : AvaloniaTestBase
         {
             var control = CreateControl(out _, out _);
 
-            Assert.Equal("Cascadia Mono", control.FontFamily);
+            Assert.Equal("Cascadia Mono", control.FontFamily.Name);
             Assert.Equal(12, control.FontSize);
             Assert.Null(control.CaretBrush);
             Assert.Null(control.SelectionBrush);
@@ -270,34 +271,26 @@ public sealed class TerminalControlTests : AvaloniaTestBase
     }
 
     [Fact]
-    public Task ApplicationResources_CanOverrideControlStyleDefaults()
+    public Task ApplicationResources_CanOverrideBrushFallbacks()
     {
         return RunInHeadlessSession(() =>
         {
             var application = Avalonia.Application.Current ?? throw new InvalidOperationException("No application is running.");
-            var hadFontFamily = application.Resources.TryGetValue("SvcSystems.UI.TerminalFontFamily", out var previousFontFamily);
-            var hadFontSize = application.Resources.TryGetValue("SvcSystems.UI.TerminalFontSize", out var previousFontSize);
             var hadCaretBrush = application.Resources.TryGetValue("SvcSystems.UI.TerminalCaretBrush", out var previousCaretBrush);
             var hadSelectionBrush = application.Resources.TryGetValue("SvcSystems.UI.TerminalSelectionBrush", out var previousSelectionBrush);
 
             try
             {
-                application.Resources["SvcSystems.UI.TerminalFontFamily"] = "Fira Code";
-                application.Resources["SvcSystems.UI.TerminalFontSize"] = 14d;
                 application.Resources["SvcSystems.UI.TerminalCaretBrush"] = Avalonia.Media.Brushes.Orange;
                 application.Resources["SvcSystems.UI.TerminalSelectionBrush"] = Avalonia.Media.Brushes.CadetBlue;
 
                 var control = CreateControl(out _, out _);
 
-                Assert.Equal("Fira Code", control.FontFamily);
-                Assert.Equal(14d, control.FontSize);
                 Assert.Same(Avalonia.Media.Brushes.Orange, control.CaretBrushForTests);
                 Assert.Same(Avalonia.Media.Brushes.CadetBlue, control.SelectionBrushForTests);
             }
             finally
             {
-                RestoreResource(application, "SvcSystems.UI.TerminalFontFamily", hadFontFamily, previousFontFamily);
-                RestoreResource(application, "SvcSystems.UI.TerminalFontSize", hadFontSize, previousFontSize);
                 RestoreResource(application, "SvcSystems.UI.TerminalCaretBrush", hadCaretBrush, previousCaretBrush);
                 RestoreResource(application, "SvcSystems.UI.TerminalSelectionBrush", hadSelectionBrush, previousSelectionBrush);
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Terminal font settings are now managed directly by the terminal control, with Cascadia Mono as the default font.
  * Removed automatic application of font, font-size, caret, and selection styling from shared resources.
  * Retained the exported 256-color palette resources for terminal color customization.

* **Documentation**
  * Updated styling guidance to reflect the new font configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->